### PR TITLE
Process submission states

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 from discord.ui import View, Select, Button
 import asyncio, random, uuid, json, pathlib, re, time
+import sys
 from datetime import datetime, timedelta
 
 # ---------- Intents & Bot ----------
@@ -11,6 +12,9 @@ intents.members = True            # privileged; enable in Dev Portal
 intents.presences = False
 intents.message_content = True
 intents.voice_states = True
+
+# Ensure that other modules importing 'main' get this running module instance (avoid double-import when run as __main__)
+sys.modules['main'] = sys.modules.get(__name__)
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 

--- a/staff_controls.py
+++ b/staff_controls.py
@@ -123,8 +123,8 @@ class StaffMatchControls(View):
             import main
             main.active_submissions.discard(self.match_id)
             # Remove from pending_upload if it exists
-            for user_id in list(main.pending_upload.keys()):
-                if main.pending_upload[user_id] == self.match_id:
+            for user_id, data in list(main.pending_upload.items()):
+                if data.get('match_id') == self.match_id:
                     del main.pending_upload[user_id]
                     break
 
@@ -405,12 +405,12 @@ class SubmissionManagementCog(discord.ext.commands.Cog):
             print(f"DEBUG - pending_upload: {pending_upload}")
             print(f"DEBUG - active_submissions type: {type(active_submissions)}")
             print(f"DEBUG - pending_upload type: {type(pending_upload)}")
-            print(f"DEBUG - active_submissions length: {len(active_submissions) if active_submissions else 'None'}")
-            print(f"DEBUG - pending_upload length: {len(pending_upload) if pending_upload else 'None'}")
+            print(f"DEBUG - active_submissions length: {len(active_submissions)}")
+            print(f"DEBUG - pending_upload length: {len(pending_upload)}")
             
             # Check if both are empty
-            has_active = active_submissions and len(active_submissions) > 0
-            has_pending = pending_upload and len(pending_upload) > 0
+            has_active = len(active_submissions) > 0
+            has_pending = len(pending_upload) > 0
             
             print(f"DEBUG - has_active: {has_active}, has_pending: {has_pending}")
             
@@ -601,7 +601,7 @@ class SubmissionManagementCog(discord.ext.commands.Cog):
             active_submissions.add(match_id)
             
             # Add to pending upload
-            pending_upload[str(interaction.user.id)] = {
+            pending_upload[interaction.user.id] = {
                 "channel_id": interaction.channel.id,
                 "match_id": match_id,
                 "started_at": time.time()
@@ -806,8 +806,8 @@ class SubmissionManagementCog(discord.ext.commands.Cog):
             import main
             main.active_submissions.discard(actual_match_id)
             # Remove from pending_upload if it exists
-            for user_id in list(main.pending_upload.keys()):
-                if main.pending_upload[user_id] == actual_match_id:
+            for user_id, data in list(main.pending_upload.items()):
+                if data.get('match_id') == actual_match_id:
                     del main.pending_upload[user_id]
                     break
 


### PR DESCRIPTION
Unify `main` module state and fix `pending_upload` deletion and key types to correctly reflect submission status.

The `/submissions` command was showing empty `active_submissions` and `pending_upload` lists due to a double-import issue where `staff_controls.py` was loading a separate instance of `main.py`. This PR adds a `sys.modules` alias to ensure `import main` always references the running module, thus unifying state. It also corrects the logic for deleting items from `pending_upload` and standardizes user ID keys to integers.

---
<a href="https://cursor.com/background-agent?bcId=bc-370bf60a-f6e9-4361-b0d6-c979cf5adb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-370bf60a-f6e9-4361-b0d6-c979cf5adb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

